### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/Facebook/Exceptions/FacebookResponseException.php
+++ b/src/Facebook/Exceptions/FacebookResponseException.php
@@ -74,7 +74,7 @@ class FacebookResponseException extends FacebookSDKException
             $data = ['error' => $data];
         }
 
-        $code = isset($data['error']['code']) ? $data['error']['code'] : null;
+        $code = isset($data['error']['code']) ? $data['error']['code'] : 0;
         $message = isset($data['error']['message']) ? $data['error']['message'] : 'Unknown error from Graph.';
 
         if (isset($data['error']['error_subcode'])) {

--- a/src/Facebook/GraphNodes/Collection.php
+++ b/src/Facebook/GraphNodes/Collection.php
@@ -184,6 +184,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
     /**
      * Get an item at a given offset.
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->items[$offset] ?? null;


### PR DESCRIPTION
* `$code` is expected to be an int, when being passed to the exception constructor.
* `offsetGet()` should be of type `mixed` which is not supported before PHP 8.0. Adding `#[\ReturnTypeWillChange]` fixes the deprecation warning though.